### PR TITLE
Added support for Cloudapp?

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,18 @@ If you have a [Campfire](http://campfirenow.com/) account and token, you can aut
     $ memegen a_dog "Hello" "Campfire world" --campfire
     
 It will prompt you for your subdomain, token, and room name the first time.
-    
+
+## Upload to Cloudapp
+
+If you have [Zach Holman](https://github.com/holman/)'s [Cloudapp
+script](https://github.com/holman/dotfiles/blob/master/bin/cloudapp), you can
+automatically upload your image to your Cloudapp account:
+
+   $ memegen y_u_no "WHY U NO" "USE CLOUDAPP" --cloudapp
+   Uploaded to http://cl.ly/3U2I3R2Z1X1I0q303N0I. 
+
+You'll have to configure `~/.cloudapp` first.
+
 ## Bash completion
 
 Source or copy `script/autocomplete.sh` inside `~/.bashrc` to get image name autocompletion.

--- a/README.md
+++ b/README.md
@@ -63,8 +63,8 @@ If you have [Zach Holman](https://github.com/holman/)'s [Cloudapp
 script](https://github.com/holman/dotfiles/blob/master/bin/cloudapp), you can
 automatically upload your image to your Cloudapp account:
 
-   $ memegen y_u_no "WHY U NO" "USE CLOUDAPP" --cloudapp
-   Uploaded to http://cl.ly/3U2I3R2Z1X1I0q303N0I. 
+    $ memegen y_u_no "WHY U NO" "USE CLOUDAPP" --cloudapp
+    Uploaded to http://cl.ly/3U2I3R2Z1X1I0q303N0I. 
 
 You'll have to configure `~/.cloudapp` first.
 

--- a/bin/memegen
+++ b/bin/memegen
@@ -8,6 +8,7 @@ require "meme_generator/cli"
 
 show_preview = ARGV.delete("show")
 campfire = ARGV.delete("--campfire") || ARGV.delete("-c")
+cloudapp = ARGV.delete("--cloudapp") || ARGV.delete("-u")
 help = ARGV.delete("--help") || ARGV.delete("-h")
 list = ARGV.delete("--list") || ARGV.delete("-l")
 
@@ -27,5 +28,5 @@ path = parse_path(image)
 if show_preview
   system "open #{path} -a Safari"
 else
-  generate(path, top.to_s, bottom.to_s, campfire)
+  generate(path, top.to_s, bottom.to_s, campfire, cloudapp)
 end

--- a/lib/meme_generator/cli.rb
+++ b/lib/meme_generator/cli.rb
@@ -30,12 +30,14 @@ def parse_path(string)
   path
 end
 
-def generate(path, top, bottom, campfire)
+def generate(path, top, bottom, campfire, cloudapp)
   if top || bottom
     output_path = MemeGenerator.generate(path, top, bottom)
 
     if campfire
       MemeGenerator::Campfire.upload(output_path)
+    elsif cloudapp
+      system("cloudapp", output_path)
     else
       puts output_path
     end


### PR DESCRIPTION
I don't have Campfire, but I do have @holman's cloudapp script:

```
https://github.com/holman/dotfiles/blob/master/bin/cloudapp
```

and can now deploy memes instantly with `-u || --cloudapp`!

Requires the `cloudapp` script to be installed and in `$PATH`. Maybe fold it into the package so it's easier to setup?
