### PR TITLE
Made changes so that MemeGenerator can be used outside the command line.

### DIFF
--- a/lib/meme_generator.rb
+++ b/lib/meme_generator.rb
@@ -5,9 +5,29 @@ class MemeGenerator
   VERSION = "1.0.8"
 
   class << self
+
+    # @return [Array<String>] Returns a list of short names for memes
+    #   available locally on disk.
+    def memes
+      meme_paths.keys
+    end
+
+    # @return [Hash] Returns a hash of of available memes.  Hash keys are
+    #   the short names for the memes and the values are paths to the meme
+    #   image on disk.
+    def meme_paths
+      local_image_path = File.expand_path("~/.memegen")
+      base = File.join(File.dirname(__FILE__), "..", "generators")
+      files = Dir.glob(["#{base}/*", "#{local_image_path}/*.*"])
+      files.inject({}) do |images,path|
+        name = path.split('/').last.sub(/\.jpg$/, '')
+        images.merge(name => path)
+      end
+    end
+
     def generate(path, top, bottom)
-      top = top.upcase
-      bottom = bottom.upcase
+      top = (top || '').upcase
+      bottom = (bottom || '').upcase
 
       canvas = Magick::ImageList.new(path)
       image = canvas.first

--- a/lib/meme_generator/cli.rb
+++ b/lib/meme_generator/cli.rb
@@ -1,7 +1,5 @@
 def images
-  local_image_path = File.expand_path("~/.memegen")
-  base = File.join(File.dirname(__FILE__), "..", "..", "generators")
-  Dir.glob(["#{base}/*", "#{local_image_path}/*.*"])
+  MemeGenerator.meme_paths.values
 end
 
 def usage


### PR DESCRIPTION
- Added MemeGenerator.memes which returns a list
  of locally available meme images (using their short name).
- Added MemeGenerator.meme_paths which returns a hash of available
  memes (keys are short names, values are paths on disk to image file).
- MemeGenerator.generate now accepts nil values for top and bottom
  captions.
