### PR TITLE
Crash without require 'meme_generator' in cli.rb

### DIFF
--- a/lib/meme_generator/cli.rb
+++ b/lib/meme_generator/cli.rb
@@ -1,3 +1,5 @@
+require 'meme_generator'
+
 def images
   MemeGenerator.meme_paths.values
 end


### PR DESCRIPTION
I don't know much about ruby, but without this require the cli gives me this:

```
# memegen -l
/var/lib/gems/1.9.1/gems/memegen-1.0.9/lib/meme_generator/cli.rb:4:in `images': uninitialized constant MemeGenerator (NameError)
	from /var/lib/gems/1.9.1/gems/memegen-1.0.9/lib/meme_generator/cli.rb:13:in `list_generators'
	from /var/lib/gems/1.9.1/gems/memegen-1.0.9/bin/memegen:18:in `<top (required)>'
	from /usr/local/bin/memegen:19:in `load'
	from /usr/local/bin/memegen:19:in `<main>'
```

Using ruby 1.9.1.

Pull request may be inappropriate. Am I doing it wrong?