### PR TITLE
Fix uninitialized constant error on --list

### DIFF
--- a/lib/meme_generator/cli.rb
+++ b/lib/meme_generator/cli.rb
@@ -1,3 +1,5 @@
+require_relative '../meme_generator.rb'
+
 def images
   MemeGenerator.meme_paths.values
 end
@@ -58,11 +60,11 @@ Source autocomplete.sh in your ~/.bashrc:
 Then source the profile:
 
     $ source ~/.bashrc
-    
+
 Or if you're using a mac
 
     $ echo "source #{path}" >> ~/.bash_profile
-    
+
 and
     $ source ~/.bash_profile
 


### PR DESCRIPTION
When executing memegen --list I got the following error:

``` bash
/Users/gianu/work/memegen/lib/meme_generator/cli.rb:2:in `images': uninitialized constant MemeGenerator (NameError)
    from /Users/gianu/work/memegen/lib/meme_generator/cli.rb:11:in `list_generators'
    from /Users/gianu/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/memegen-1.0.9/bin/memegen:18:in `<top (required)>'
    from /Users/gianu/.rbenv/versions/2.0.0-p0/bin/memegen:23:in `load'
    from /Users/gianu/.rbenv/versions/2.0.0-p0/bin/memegen:23:in `<main>'
```

I'm using rbenv 0.4.0-22-gea3203d and ruby 2.0.0-p0.

The fix that I found (and it's working for me) is to add the require_relative in cli.rb.
