### PR TITLE
Fix for cli errors.

### DIFF
--- a/lib/meme_generator/cli.rb
+++ b/lib/meme_generator/cli.rb
@@ -1,3 +1,5 @@
+require "meme_generator"
+
 def images
   MemeGenerator.meme_paths.values
 end


### PR DESCRIPTION
When running `memegen --list`, I see "uninitialized constant
MemeGenerator (NameError)".

```
/home/miked/.rvm/gems/ruby-2.1.5/gems/memegen-1.0.9/lib/meme_generator/cli.rb:2:in `images': uninitialized constant MemeGenerator (NameError)
	from /home/miked/.rvm/gems/ruby-2.1.5/gems/memegen-1.0.9/lib/meme_generator/cli.rb:11:in `list_generators'
	from /home/miked/.rvm/gems/ruby-2.1.5/gems/memegen-1.0.9/bin/memegen:18:in `<top (required)>'
```
